### PR TITLE
fix(package.json): Hardcoded web3 at 1.0.0-beta.37

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "eth-provider": "0.1.4",
     "pify": "^4.0.1",
     "thunky": "^1.0.3",
-    "web3": "^1.0.0-beta.36"
+    "web3": "1.0.0-beta.37"
   },
   "devDependencies": {
     "ava": "^0.25.0",


### PR DESCRIPTION
"Fixes" https://github.com/ethereum/web3.js/issues/2263

call stack from file manager:
  afm:kernel:lib:actionCreators:login Error: Error: Validation error:
Response should be of type Object
  afm:kernel:lib:actionCreators:login     at Function.validate
(/Users/vipyne/Documents/littlstar/ara/ara-file-manager/node_modules/web3/node_modules/web3-providers/dist/web3-providers.cjs.js:76:14)
  afm:kernel:lib:actionCreators:login     at
/Users/vipyne/Documents/littlstar/ara/ara-file-manager/node_modules/web3/node_modules/web3-providers/dist/web3-providers.cjs.js:880:57
  afm:kernel:lib:actionCreators:login     at <anonymous>
  afm:kernel:lib:actionCreators:login     at process._tickCallback
(internal/process/next_tick.js:188:7) +206ms

## Proposed Changes

  - hardcode web3 at latest stable version for Ara `1.0.0-beta.37`
  -
  -